### PR TITLE
async transform failing when not calling write with string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,11 +273,11 @@ CSV.prototype.write = function(chunk, preserve) {
   }
   if (typeof chunk === 'string' && !preserve) {
     this.parser.write(chunk);
-  } else if (Array.isArray(chunk) && !this.state.transforming) {
+  } else if (Array.isArray(chunk) && (!this.state.transforming || this.transformer.async())) {
     csv = this;
     this.transformer.write(chunk);
   } else {
-    if (preserve || this.state.transforming) {
+    if (preserve || (this.state.transforming && !this.transformer.async())) {
       this.stringifier.write(chunk);
     } else {
       this.transformer.write(chunk);

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -89,6 +89,7 @@ Transformer = function(csv) {
     parallel: 100
   };
   this.todo = [];
+  this._async = null;
   return this;
 };
 
@@ -181,7 +182,7 @@ Transformer.prototype.write = function(line) {
   if (!this.callback) {
     return finish(line);
   }
-  sync = this.callback.length !== 3;
+  sync = !this.async();
   csv.state.transforming++;
   self = this;
   done = function(err, line) {
@@ -240,6 +241,11 @@ Transformer.prototype.end = function() {
   if (this.csv.state.transforming === 0) {
     return this.emit('end');
   }
+};
+
+Transformer.prototype.async = function() {
+  this._async = this._async === null ? this.callback && this.callback.length === 3 : this._async;
+  return this._async;
 };
 
 module.exports = function(csv) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -251,12 +251,12 @@ CSV.prototype.write = (chunk, preserve) ->
   if typeof chunk is 'string' and not preserve
     @parser.write chunk
   # Chunk is an array, we transform it
-  else if Array.isArray(chunk) and not @state.transforming
+  else if Array.isArray(chunk) and (not @state.transforming or @transformer.async())
     csv = @
     @transformer.write chunk
   # Chunk is an object, we transform it or stringify it
   else
-    if preserve or @state.transforming
+    if preserve or (@state.transforming and not @transformer.async())
       @stringifier.write chunk
     else
       @transformer.write chunk

--- a/src/transformer.coffee
+++ b/src/transformer.coffee
@@ -82,6 +82,7 @@ Transformer = (csv) ->
   @running = 0
   @options = parallel: 100
   @todo = []
+  @_async = null
   @
 Transformer.prototype.__proto__ = stream.prototype
 ### no doc
@@ -147,7 +148,7 @@ Transformer.prototype.write = (line) ->
     self.emit 'end', csv.state.count if csv.state.transforming is 0 and self.closed is true
   csv.state.count++
   return finish line unless @callback
-  sync = @callback.length isnt 3
+  sync = not @async()
   csv.state.transforming++
   self = @
   done = (err, line) ->
@@ -189,5 +190,9 @@ Transformer.prototype.end = ->
   @closed = true
   @emit 'end' if @csv.state.transforming is 0
 
+
+Transformer.prototype.async = ->
+  @_async = if @_async is null then @callback and @callback.length is 3 else @_async
+  @_async
 module.exports = (csv) -> new Transformer csv
 module.exports.Transformer = Transformer

--- a/test/transform.coffee
+++ b/test/transform.coffee
@@ -195,7 +195,7 @@ describe 'transform', ->
 
   describe 'async', ->
 
-    it 'should output the record if passed in the callback as an arraw', (next) ->
+    it 'should output the record if passed in the callback as an array', (next) ->
       csv()
       .from('a1,b1\na2,b2')
       .to (data) ->
@@ -276,3 +276,21 @@ describe 'transform', ->
         nextTick ->
           data.foo = 'bar';
           callback null, data
+          
+    it 'should accept more records while still transforming', (next) ->
+      csv()
+      .from.array([{a: '1', b: '2'}, {a: '3', b: '4'}])
+      .to( (data) ->
+        data.should.eql """
+        a_col,b_col
+        1,2
+        3,4
+        """
+        next()
+      , columns: ['a_col', 'b_col'], header: true)
+      .transform (data, index, callback) ->
+        nextTick ->
+          row = 
+            a_col: data.a
+            b_col: data.b
+          callback null, row

--- a/test/transform.coffee
+++ b/test/transform.coffee
@@ -278,11 +278,12 @@ describe 'transform', ->
           callback null, data
           
     it 'should accept more records while still transforming', (next) ->
-      csv()
+      test = csv()
       .from.array([{a: '1', b: '2'}, {a: '3', b: '4'}])
       .to( (data) ->
         data.should.eql """
         a_col,b_col
+        5,6
         1,2
         3,4
         """
@@ -290,7 +291,10 @@ describe 'transform', ->
       , columns: ['a_col', 'b_col'], header: true)
       .transform (data, index, callback) ->
         nextTick ->
+          arr = Array.isArray data
           row = 
-            a_col: data.a
-            b_col: data.b
+            a_col: if arr then data[0] else data.a
+            b_col: if arr then data[1] else data.b
           callback null, row
+          
+      test.write ['5', '6']


### PR DESCRIPTION
when using async transform, if the input data comes faster
than the async process can deal with it, the stringifier
is used instead. This is because line 259 of index.coffee
says to use the stringifier if still tranforming and because
the async transformer has not called the callback yet it is
still transforming. This results in a bunch of empty rows
followed by the header (if used) and a single line of output.

One solution I came up with was altering the mentioned line
to only check if preserve was set, but I don't know enough
to know if that fixes everything or just my use case.